### PR TITLE
Add '#' to KeyCode list

### DIFF
--- a/src/ipa-sil.txt
+++ b/src/ipa-sil.txt
@@ -1,4 +1,4 @@
-KeyCode=+!\%&'-./0123456789:<=>$?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+KeyCode=+!\%&'-./0123456789:<=>$?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"#
 Length=6
 Prompt=
 ConstructPhrase=


### PR DESCRIPTION
In the current version of this project, keymaps that include `#`, like `#4` for '˥', are broken. This is fixed by adding the character `#` to `KeyCode` in `ipa-sil.txt`.