### PR TITLE
Add missing characters to KeyCode

### DIFF
--- a/src/ipa-sil.txt
+++ b/src/ipa-sil.txt
@@ -1,4 +1,4 @@
-KeyCode=+!\%&'-./0123456789:<=>$?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"#
+KeyCode=+!\%&'-./0123456789:<=>$?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"#*,()
 Length=6
 Prompt=
 ConstructPhrase=


### PR DESCRIPTION
Hey! I noticed that sequences involving `*`, such as `***` for the *very short* mark, don't currently work. This time around I took the liberty of using a script to check through all of the mappings to see if there are any other missing characters, and I ended up with these: `*,()`. This PR adds those characters to `KeyCode`, and I can confirm that the relevant sequences work with that change :)

That being said, it seems that `,()` (all missing chars except `*`) are only involved in mappings to the sequence itself (e.g. `,` to ',', `((` to "((" etc.), so while I'm tending towards including them for consistency's sake, they could also be omitted without loss of functionality.